### PR TITLE
Fixes #12 - Add check for (new, correct) `macOS` platform value.

### DIFF
--- a/uach-retrofill.js
+++ b/uach-retrofill.js
@@ -119,7 +119,9 @@ async function getUserAgentUsingClientHints(hints) {
         newUA += GetCrosSpecificString(values);
       } else if (values.platform == 'Windows') {
         newUA += GetWindowsSpecificString(values);
-      } else if (values.platform == 'Mac OS X') {
+        // TODO: 'Mac OS X' can be removed in the near future
+        // See Issue #13
+      } else if (['macOS', 'Mac OS X'].includes(values.platform)) {
         newUA += GetMacSpecificString(values);
       } else if (values.platform == 'Android') {
         newUA += GetAndroidSpecificString(values);


### PR DESCRIPTION
We keep the check for 'Mac OS X' for ease in transition, in
case anybody is using this until it's safe to remove (#13).

PTAL @rowan-m 

(Let's hold off on merging until the corresponding change lands in Chromium, possibly today or early next week).