### PR TITLE
Remove creating double spaces in cases where arch is missing for CrOS

### DIFF
--- a/uach-retrofill.js
+++ b/uach-retrofill.js
@@ -39,6 +39,9 @@ async function getUserAgentUsingClientHints(hints) {
     } else if (values.architecture == 'arm' && values.bitness == '32') {
       osCPUFragment = 'armv7l';
     }
+    if (osCPUFragment == '') {
+      return `X11; CrOS ${values.platformVersion}`;
+    }
     return `X11; CrOS ${osCPUFragment} ${values.platformVersion}`;
   }
 


### PR DESCRIPTION
Small bug fix so that the created string is formatted right when os fragment is empty.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR