### PR TITLE
Expand the regex

### DIFF
--- a/uach-retrofill.js
+++ b/uach-retrofill.js
@@ -1,4 +1,4 @@
-d
+/**
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');

--- a/uach-retrofill.js
+++ b/uach-retrofill.js
@@ -1,4 +1,4 @@
-/**
+d
  * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
@@ -102,13 +102,13 @@ async function getUserAgentUsingClientHints(hints) {
   // Verify that this is a Chromium-based browser
   let is_chromium = false;
   let chromium_version;
-  const is_reduced_ua_pattern = new RegExp('AppleWebKit/537.36 \\(KHTML, like Gecko\\) Chrome/\\d+.0.0.0 (Mobile )?Safari/537.36$');
+  const is_chrome_ua_pattern = new RegExp('AppleWebKit/537.36 \\(KHTML, like Gecko\\) Chrome/\\d+.\\d+.\\d+.\\d+ (Mobile )?Safari/537.36$');
   navigator.userAgentData.brands.forEach(value => {
     if (value.brand == 'Chromium') {
       // Let's double check the UA string as well, so we don't accidentally
       // capture a headless browser or friendly bot (which should report as
       // HeadlessChrome or something entirely different).
-      is_chromium = is_reduced_ua_pattern.test(navigator.userAgent);
+      is_chromium = is_chrome_ua_pattern.test(navigator.userAgent);
       chromium_version = value.version;
     } 
   });


### PR DESCRIPTION
Fixes #25 

Current regex is too strict and creates a scenario where the retrofill kicks in only when the UA is reduced. A problem with the approach is that when we run experiments today with the retrofill, we are not exercising the retrofill since we keep returning the UA as it is today.

This regex expansion kicks in the retrofill to Chrome UAs excluding CriOS, webview, Edge and other Chromium based browsers.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR